### PR TITLE
docker container can be restarted

### DIFF
--- a/galaxy/export_user_files.py
+++ b/galaxy/export_user_files.py
@@ -11,7 +11,8 @@ def change_path( src ):
     """
         src will be copied to /export/`src` and a symlink will be placed in src pointing to /export/
     """
-    if os.path.exists( src ):
+    # assume if path is a symlink we are restarting a container and no setup required
+    if os.path.exists( src ) and not os.path.islink( src.rstrip('/') ):
         dest = os.path.join( '/export/', src.strip('/') )
         # if destination is empty move all files into /export/ and symlink back to source
         if not os.path.exists( dest ):


### PR DESCRIPTION
previously line 26 os.path.isdir( src) would be true even if src was a symlink,
the following line shutil.rmtree( src ) would descend into the symlinked directory and remove files
but not remove the symlink, this would cause data to be lost if a container was restarted (instead of re-running the image)
