### PR TITLE
Bump version, mention exporting /dev/shm

### DIFF
--- a/galaxy-deeptools/Dockerfile
+++ b/galaxy-deeptools/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION       0.3
 
-FROM bgruening/galaxy-stable:15.03
+FROM bgruening/galaxy-stable:15.05
 
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 

--- a/galaxy-deeptools/README.md
+++ b/galaxy-deeptools/README.md
@@ -36,6 +36,10 @@ With the additional ``-v /home/user/galaxy_storage/:/export/`` parameter, docker
 
 This enables you to have different export folders for different sessions - means real separation of your different projects.
 
+Note that the default size allocated to `/dev/shm` is too small for many deeptools programs. This size can either be changed from within the container or simply exported from the base system with `-v /dev/shm:/dev/shm`:
+
+``docker run -d -p 8080:80 -v /home/user/galaxy_storage/:/export/ -v /dev/shm:/dev/shm bgruening/galaxy-deeptools``
+
 
 Users & Passwords
 ================


### PR DESCRIPTION
This should bump the Galaxy version to 15.05. Also, a number of the deeptools programs need to write temporary files, which will be placed in `/dev/shm`. This is fixed to 64 megs in the Docker container and can't easily be changed. It's simple enough to just export the system `/dev/shm`.